### PR TITLE
Add Newman HTML test output

### DIFF
--- a/.github/workflows/EventsAPITestSuite.yml
+++ b/.github/workflows/EventsAPITestSuite.yml
@@ -3,7 +3,7 @@ name: Run Newman as a GitHub Action
 
 # How is this action triggered?
 on:
-  schedule: #Run on a schedule
+  schedule: # Run on a schedule
   - cron: "0 10,16 * * *"
   workflow_dispatch: #Trigger manually
 
@@ -18,14 +18,33 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v1
 
-    # 2. Run Newman with params
+    # 2. Install Newman HTML Reporter
+    - name: Install Newman HTML Reporter
+      run: npm install -g newman-reporter-htmlextra
+
+    # 3. Run Newman with params
     - name: Run Newman
       id: run-newman
       uses: anthonyvscode/newman-action@v1
       with:
         collection: HackGreenvilleEventsAPITestSuite/EventsAPI.json
-        reporters: cli
+        reporters: cli, html
 
-    # 3. View Test Results in Console
+    # 4. View Test Results in Console
     - name: Output summary to console
       run: echo ${{ steps.run-newman.outputs.summary_full }} #summary_full is important!
+    
+    # 5. View results in HTML
+    - name: View results in HTML
+      run: newman run HackGreenvilleEventsAPITestSuite/EventsAPI.json -r htmlextra --reporter-htmlextra-export wwcgvl-newman.html
+      
+  # 6. Upload results to artifacts
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v3
+      with:
+        name: newman-report
+        path: wwcgvl-newman.html
+
+    
+
+


### PR DESCRIPTION
Using Newman [HTMLExtra](https://www.npmjs.com/package/newman-reporter-htmlextra)
Addresses #93 

**I did not add the functionality to automatically download the artifact and product an HTML link - this can be added in future iterations

The resulting HTML file is sent to GitHub artifacts: [Example](https://github.com/WomenWhoCode/WWCodeGreenville/actions/runs/6684790163)
<img width="844" alt="Screenshot 2023-10-29 at 12 27 54 PM" src="https://github.com/WomenWhoCode/WWCodeGreenville/assets/18410214/82f555ee-589b-4db1-b5a0-ab7723acc085">
