### PR TITLE
Add API test to make sure status is a known value to us.

### DIFF
--- a/HackGreenvilleEventsAPITestSuite/EventsAPI.json
+++ b/HackGreenvilleEventsAPITestSuite/EventsAPI.json
@@ -35,12 +35,21 @@
 							"});",
 							"",
 							"// Functional Testing Verification",
-							"//Event Name Exists",
-							"    pm.test(\"Event Name is not empty and exists\", function () {",
-							"        \tfor (let i=0; i <responseData.length; i++) {",
-							"        \t\tpm.expect(responseData[i].event_name).to.not.be.empty;",
+							"",
+							"// Event Name Exists",
+							"pm.test(\"Event Name is not empty and exists\", function () {",
+							"    for (let i=0; i <responseData.length; i++) {",
+							"       	pm.expect(responseData[i].event_name).to.not.be.empty;",
 							"        }",
-							"    });",
+							"});",
+							"// Status is Valid",
+							"pm.test(\"Status is Valid\", function () {",
+							"    for (let i=0; i <responseData.length; i++) {",
+        						"		pm.expect(responseData[i].status).to.be.oneOf([\"past\", \"cancelled\", \"upcoming\"]);",			
+							"    	}",
+							"});",
+
+
 							"//TBD"
 						],
 						"type": "text/javascript"

--- a/HackGreenvilleEventsAPITestSuite/EventsAPI.json
+++ b/HackGreenvilleEventsAPITestSuite/EventsAPI.json
@@ -4,8 +4,8 @@
 		"name": "HackGreenville Events API Test Suite",
 		"description": "This test suite runs on an automated schedule from the Women Who Code Greenville repository on a schedule from a Github Action.\n\n[https://github.com/WomenWhoCode/WWCodeGreenville/](https://github.com/WomenWhoCode/WWCodeGreenville/)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "14924326",
-		"_collection_link": "https://www.postman.com/jen-bauer/workspace/wwcode-gvl-api-training/collection/14924326-d4b4558a-8cff-422d-abe8-7b26f227e9ca?action=share&source=collection_link&creator=14924326"
+		"_exporter_id": "30719102",
+		"_collection_link": "https://www.postman.com/jen-bauer/workspace/wwcode-gvl-api-training/collection/14924326-d4b4558a-8cff-422d-abe8-7b26f227e9ca?action=share&source=collection_link&creator=30719102"
 	},
 	"item": [
 		{
@@ -38,18 +38,18 @@
 							"",
 							"// Event Name Exists",
 							"pm.test(\"Event Name is not empty and exists\", function () {",
-							"    for (let i=0; i <responseData.length; i++) {",
-							"       	pm.expect(responseData[i].event_name).to.not.be.empty;",
-							"        }",
+							"    for (let i=0; i<responseData.length; i++) {",
+							"        pm.expect(responseData[i].event_name).to.not.be.empty;",
+							"    }",
 							"});",
+							"",
 							"// Status is Valid",
-							"pm.test(\"Status is Valid\", function () {",
-							"    for (let i=0; i <responseData.length; i++) {",
-        						"		pm.expect(responseData[i].status).to.be.oneOf([\"past\", \"cancelled\", \"upcoming\"]);",			
-							"    	}",
+							"pm.test(\"Status is valid and known to us\", function () {",
+							"    for (let i=0; i<responseData.length; i++) {",
+							"        pm.expect(responseData[i].status).to.be.oneOf([\"past\", \"cancelled\", \"upcoming\"]);",
+							"    }",
 							"});",
-
-
+							"",
 							"//TBD"
 						],
 						"type": "text/javascript"


### PR DESCRIPTION
# Pull Request

## Description
Add API test to make sure status is a known value to us.  Inspired from (https://github.com/hackgvl/events-api/issues/83).

## Motivation
Eventbrite and meetup statuses are not always known to our python code.  So, added a test to make sure that if there is an unknown status to our python code, we catch it earlier.

## Testing Procedures
Tested in Postman.  I will apply the change on the postman code too.

## Checklist
- [ ] Code adheres to project coding standards.
- [ ] Tests cover the added or modified code.
- [ ] Documentation has been updated, if necessary.
- [ ] All new and existing tests pass successfully.
- [ ] The pull request is up to date with the latest changes from the main branch.

## Reviewer Guidelines
I wanted to add a test to make sure status is a known value to our python code and developers.

## Screenshots or Visuals
![Screen Shot 2023-11-03 at 10 46 59 AM](https://github.com/WomenWhoCode/WWCodeGreenville/assets/103586617/14fbad66-6a0e-4c7a-abb8-bb6b444d9892)

## Additional Information
Links recommended from #hg-labs channel in HackGreenville
(https://www.eventbrite.com/platform/api#/reference/event)
(https://www.meetup.com/api/schema/#EventStatus)

Fixes [#[94]](https://github.com/WomenWhoCode/WWCodeGreenville/issues/94)
